### PR TITLE
This print statement was only used for debugging and is not needed.

### DIFF
--- a/openomni/bin/omni_listen_rfcat
+++ b/openomni/bin/omni_listen_rfcat
@@ -38,7 +38,6 @@ def quick_setup(device, bitrate=40625, check=True):
 				x += 1
 
 		except ChipconUsbTimeoutException:
-			print "ChipconUsbTimeoutException"
 			time.sleep(0.5)
 
 


### PR DESCRIPTION
Removing a print statement from omni_listen_rfcat because it was only used to debug the following exception. 

Looking at the rfcat code there is a loop that will raise(ChipconUsbTimeoutException()) every time, based on the loop criteria: while (time.time() - startTime)*1000 < wait

Here's a look at the related rfcat loop if you're curious to see where this exception is being raised.

/usr/local/lib/python2.7/dist-packages/rflib/chipcon_usb.py
```
    def recv(self, app, cmd=None, wait=USB_RX_WAIT):
        '''
        high-level USB EP5 receive.  
        checks the mbox for app "app" and command "cmd" and returns the next one in the queue
        if any of this does not exist yet, wait for a RECV event until "wait" times out.
        RECV events are generated by the low-level recv thread "runEP5_recv()"
        '''
        startTime = time.time()
        self.recv_event.clear() # an event is only interesting if we've already failed to find our message

        while (time.time() - startTime)*1000 < wait:
            try:
                b = self.recv_mbox.get(app)
                if b:
                    if self._debug: print>>sys.stderr, "Recv msg",app,b,cmd
                    if cmd is None:
                        keys = b.keys()
                        if len(keys):
                            cmd = b.keys()[-1] # just grab one.   no guarantees on the order

                if b is not None and cmd is not None:
                    q = b.get(cmd)
                    if self._debug: print >>sys.stderr,"debug(recv) q='%s'"%repr(q)

                    if q is not None and self.rsema.acquire(False):
                        if self._debug>3: print ("rsema.UNlocked", "rsema.locked")[self.rsema.locked()],2
                        try:
                            resp, rt = q.pop(0)

                            self.rsema.release()
                            if self._debug>3: print ("rsema.UNlocked", "rsema.locked")[self.rsema.locked()],2

                            # bring it on home...  this is the way out.
                            return resp[4:], rt

                        except IndexError:
                            pass

                        except AttributeError:
                            sys.excepthook(*sys.exc_info())
                            pass

                        self.rsema.release()

                self.recv_event.wait((wait - (time.time() - startTime)*1000)/1000) # wait on recv event, with timeout of remaining time
                self.recv_event.clear() # clear event, if it's set

            except KeyboardInterrupt:
                sys.excepthook(*sys.exc_info())
                break
            except:
                sys.excepthook(*sys.exc_info())

            time.sleep(0.001)

        raise(ChipconUsbTimeoutException())
```