### PR TITLE
Support json in omni_listen_rfcat command

### DIFF
--- a/openomni/bin/omni_listen_rfcat
+++ b/openomni/bin/omni_listen_rfcat
@@ -4,6 +4,7 @@ from rflib import *
 import binascii
 import time
 import datetime
+import argparse
 from openomni import Packet
 
 def flip_bytes(data):
@@ -11,7 +12,7 @@ def flip_bytes(data):
 	bytes = map(lambda x: ord(x) ^ 0xff, data)
 	return bytearray(bytes).__str__()
 
-def quick_setup(device, bitrate=40625, check=True):
+def quick_setup(device, bitrate=40625, json=False):
 	"""quick_setup is used to setup rfcat to quickly decode omnipod signals"""
 	device.setFreq(433.91e6)
 	device.setMdmModulation(MOD_2FSK)
@@ -32,9 +33,13 @@ def quick_setup(device, bitrate=40625, check=True):
 			x = 0
 			while x < len(pkt):
 				packet = Packet(pkt[:len(pkt) - (x + 1)])
+				packet.received_at = rcv_time
 				if packet.is_valid():
 					#print packet.data.encode('hex')
-					print "%s %s" % (rcv_time.isoformat(), packet)
+					if json:
+						print packet.as_json()
+					else:
+						print packet
 				x += 1
 
 		except ChipconUsbTimeoutException:
@@ -44,9 +49,15 @@ def quick_setup(device, bitrate=40625, check=True):
 	sys.stdin.read(1)
 
 def main(options=None):
-	d = RfCat(0, debug=False)
-	quick_setup(d)
 
+    parser = argparse.ArgumentParser(description='Capture omnipod packets using rfcat.')
+    parser.add_argument('--json', action='store_true',
+                        help='print as json (default: text line)')
+
+    args = parser.parse_args()
+
+    d = RfCat(0, debug=False)
+    quick_setup(d, json=args.json)
 
 if __name__ == '__main__':
 	main()

--- a/openomni/packet.py
+++ b/openomni/packet.py
@@ -70,7 +70,7 @@ class Packet:
         base_str += "ID1:%s PTYPE:%s SEQ:%02s" % (
                 self.pod_address_1,
                 self.packet_type_str,
-                self.sequence, '02',
+                self.sequence,
             )
 
         if self.packet_type == Packet.PACKET_TYPE_ACK:


### PR DESCRIPTION
Example:
```
$ omni_listen_rfcat --json 
{
    "body": "0080b0",
    "body_len": 3,
    "byte9": 56,
    "crc": 110,
    "message_type": "0e01",
    "packet_type": 5,
    "packet_type_str": "PDM",
    "pod_address_1": "1f01482a",
    "pod_address_2": "1f01482a",
    "raw_packet": "1f01482ab41f01482a38030e010080b06e",
    "received_at": "2016-06-27T20:23:33.259982",
    "sequence": 20
}
{
    "body": "01582800001497ff0223",
    "body_len": 10,
    "byte9": 60,
    "crc": 229,
    "message_type": "1d18",
    "packet_type": 7,
    "packet_type_str": "POD",
    "pod_address_1": "1f01482a",
    "pod_address_2": "1f01482a",
    "raw_packet": "1f01482af51f01482a3c0a1d1801582800001497ff0223e5",
    "received_at": "2016-06-27T20:23:33.383734",
    "sequence": 21
}
```