### PR TITLE
Remove timeout

### DIFF
--- a/openomni/bin/omni_send_rfcat
+++ b/openomni/bin/omni_send_rfcat
@@ -60,7 +60,7 @@ def main(options=None):
 
     while not keystop():
     	try:
-    		pkt,ts = d.RFrecv(timeout=80000)
+    		pkt,ts = d.RFrecv()
     		pkt = Packet.flip_bytes(pkt)
     		rcv_time = datetime.datetime.now()
 


### PR DESCRIPTION
This timeout often prevents rfcat from being able to receive a POD packet. Removing it produces much more consistent results. 