### PR TITLE
 Handle legacy text format lack of date better

### DIFF
--- a/openomni/packet.py
+++ b/openomni/packet.py
@@ -35,6 +35,7 @@ class Packet(object):
     MAX_CON_BODY_SEGMENT_LEN = 30
 
     def __init__(self, data=""):
+        self.data = data
         self.received_at = None
         self.packet_type = None
         self.body = None
@@ -70,9 +71,16 @@ class Packet(object):
             self.body = data[5:-1]
             self.crc = ord(data[-1])
 
-    @staticmethod
-    def from_hex(hex_str):
-        return Packet(hex_str.decode("hex"))
+    @classmethod
+    def from_hex(cls, hex_str):
+        return cls(hex_str.decode("hex"))
+
+    @classmethod
+    def from_string(cls, raw_string):
+        c = cls()
+        c.assign_from_string(raw_string)
+        c.data = c.tx_data()
+        return c
 
     @staticmethod
     def flip_bytes(data):
@@ -85,9 +93,14 @@ class Packet(object):
             elems = line.split(' ')
             self.pod_address_2 = None
             self.byte9 = None
-            self.received_at = dateutil.parser.parse(elems[0])
+            self.received_at = None
             legacy_mtype = bytes()
-            for elem in elems[1:]:
+            for i, elem in enumerate(elems):
+                if self.received_at is None and i < 1:
+                    try:
+                        self.received_at = dateutil.parser.parse(elem)
+                    except ValueError:
+                        pass
                 (key,v) = elem.split(':')
                 if key == "ID1":
                     self.pod_address_1 = v
@@ -111,11 +124,8 @@ class Packet(object):
                     legacy_mtype = v.decode('hex')
                 if key == "BODY":
                     self.body = legacy_mtype + v.decode('hex')
-        except ValueError:
+        except (ValueError, OverflowError):
             self.body = None
-        except OverflowError:
-            self.body = None
-
         return self
 
 

--- a/openomni/packet.py
+++ b/openomni/packet.py
@@ -99,9 +99,10 @@ class Packet(object):
                 if self.received_at is None and i < 1:
                     try:
                         self.received_at = dateutil.parser.parse(elem)
+                        continue
                     except ValueError:
                         pass
-                (key,v) = elem.split(':')
+                (key,v) = elem.split(':', 1)
                 if key == "ID1":
                     self.pod_address_1 = v
                 if key == "ID2":

--- a/openomni/packet_test.py
+++ b/openomni/packet_test.py
@@ -37,8 +37,15 @@ class PacketTestCase(unittest.TestCase):
         self.assertEqual(packet.packet_type, PacketType.ACK)
         self.assertEqual(packet.raw_hex(), "1f01482a5e1f01482ae5")
 
+    def test_read_packet_legacy_output_format_no_date(self):
+        packet = Packet.from_string("ID1:1f014829 PTYPE:POD SEQ:14 ID2:1f014829 B9:24 BLEN:10 MTYPE:1d18 BODY:02ada800002be7ff021c CRC:40")
+        self.assertTrue(packet.is_valid())
+        self.assertEqual(packet.packet_type, PacketType.POD)
+        self.assertEqual(packet.body_len, 10)
+        self.assertEqual(len(packet.body), 12)  # Includes crc
+
     def test_read_packet_output_format(self):
-        packet = Packet().assign_from_string("2016-06-17T20:50:34.882742 ID1:1f014829 PTYPE:POD SEQ:14 ID2:1f014829 B9:24 BLEN:10 MTYPE:1d18 BODY:02ada800002be7ff021c CRC:40")
+        packet = Packet.from_string("2016-06-17T20:50:34.882742 ID1:1f014829 PTYPE:POD SEQ:14 ID2:1f014829 B9:24 BLEN:10 MTYPE:1d18 BODY:02ada800002be7ff021c CRC:40")
         self.assertTrue(packet.is_valid())
         self.assertEqual(packet.packet_type, PacketType.POD)
         self.assertEqual(packet.body_len, 10)


### PR DESCRIPTION
Fixes parsing of legacy string formatted packets as used in the data capture spreadsheet.

It was assumed that the first element in the string was a timestamp, which isn't always present for the older formatted packets.

Add tests to assert this works going forward.