### PR TITLE
Moved most prerequisites to setup.py requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .cache
 .DS_Store
 *.swp
+venv

--- a/README.md
+++ b/README.md
@@ -23,15 +23,9 @@ One of the following.  If you use the TI stick, you will need to flash firmware 
 ## Installation
 
 Prerequisites:
-* python 2.7 (already installed on MacOS)
+* python 2.7 (already installed on MacOS, for windows, download it [here](https://www.python.org/downloads/release/python-2714/))
 * [pip](https://pip.readthedocs.io/en/stable/installing/)
-* [rfcat](https://github.com/atlas0fd00m/rfcat)
-* [enum34](https://pypi.python.org/pypi/enum34) - Install with `pip install enum34`
-* PyUSB - you can install this with pip: `pip install pyusb`, or `sudo pip install pyusb`
 * On mac, you'll need libusb. `brew install libusb` (If you don't have Homebrew installed, go here first: https://brew.sh/)
-* Tip: You may need to install the dateutil package at https://pypi.python.org/pypi/python-dateutil. Extract it to somewhere and run the command:
-
-python setup.py install
 
 You can install openomni in editable mode like this:
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 crccheck
 python-dateutil
+pyusb
+git+https://github.com/atlas0fd00m/rfcat
 enum34>=1.1.6 ; python_version <= '2.7'

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,15 @@ setup(name='openomni',
         'openomni/bin/omni_explore',
         'openomni/bin/omni_send_rfcat',
         'openomni/bin/omni_forloop'],
+      dependency_links=[
+        'https://github.com/atlas0fd00m/rfcat/tarball/master#egg=rfcat-1.0',
+      ],
       packages=find_packages(),
       install_requires=[
           'crccheck',
+          'python-dateutil',
           'enum34;python_version<"3.4"',
+          'pyusb',
+          'rfcat>=1.0'
       ],
       zip_safe=False)


### PR DESCRIPTION
I was going over the installer steps (just ordered the rfcat to help) and saw the many prerequisites steps, which gave an issue with the rflib which could not be found. Because I had not used the pip setup for rfcat. I am probably not the only one, so I moved all pip install requirements including rfcat into the pip setup step to make the install steps a bit simpler. 