### PR TITLE
Added pip option to properly download rfcat from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can install openomni in editable mode like this:
 ```
 git clone https://github.com/openaps/openomni.git
 cd openomni
-pip install -e .
+pip install -e . --process-dependency-links
 ```
 ** Note: You may need to add 'sudo' before the pip install line if you are using a system python install.
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='openomni',
       install_requires=[
           'crccheck',
           'python-dateutil',
-          'enum34;python_version<"3.4"',
+          'enum34',
           'pyusb',
           'rfcat>=1.0'
       ],


### PR DESCRIPTION
Forgot to add the dependancy link option in the readme during the pip install step, else you get:
'Could not find a version that satisfies the requirement rfcat (from openomni==0.1) (from versions: )
No matching distribution found for rfcat (from openomni==0.1)'